### PR TITLE
Change 80 to 443 port for kibana service

### DIFF
--- a/secrets&vso.sh
+++ b/secrets&vso.sh
@@ -58,7 +58,7 @@ EOF
 
 ## Expose Kibana service
 kubectl get kibana
-kubectl expose deployment quickstart-kb --port 80 --target-port 5601 --type LoadBalancer
+kubectl expose deployment quickstart-kb --port 443 --target-port 5601 --type LoadBalancer
 kubectl get secret quickstart-es-elastic-user -o=jsonpath='{.data.elastic}' | base64 --decode; echo
 
 ## Add HashiCorp Helm repository and update


### PR DESCRIPTION
elasticsearch operator expose kibana by tls.
Using port 443 is more preferable I think.
It could be misleading to use port 80.